### PR TITLE
Enable 'discard' option only on selected filesystems

### DIFF
--- a/0028-enable-discard-option-for-dom0-filesystems-by-defaul.patch
+++ b/0028-enable-discard-option-for-dom0-filesystems-by-defaul.patch
@@ -23,7 +23,7 @@ index 8d2390ddb..6117c6d0a 100644
                      break
              if device.encrypted:
                  options += ",x-systemd.device-timeout=0"
-+            if mountpoint.startswith('/'):
++            if fstype in ('ext4', 'btrfs', 'xfs', 'vfat'):
 +                options += ",discard"
              devspec = device.fstab_spec
              dump = device.format.dump


### PR DESCRIPTION
Instead of checking mountpoint, enable it on filesystems known to
support 'discard' option and available in the installer.

Fixed QubesOS/qubes-issues#5604