### PR TITLE
Increase Xen's default gnttab_max_frames and gnttab_max_maptrack_frames

### DIFF
--- a/0007-Add-Qubes-grub2-default-parameters.patch
+++ b/0007-Add-Qubes-grub2-default-parameters.patch
@@ -70,7 +70,7 @@ index 1154f43d8..604ad6649 100644
          defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
          defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
          defaults.write("GRUB_THEME=\"/boot/grub2/themes/qubes/theme.txt\"\n")
-+        defaults.write("GRUB_CMDLINE_XEN_DEFAULT=\"console=none dom0_mem=min:1024M dom0_mem=max:4096M iommu=no-igfx ucode=scan smt=off\"\n")
++        defaults.write("GRUB_CMDLINE_XEN_DEFAULT=\"console=none dom0_mem=min:1024M dom0_mem=max:4096M iommu=no-igfx ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096\"\n")
 +        defaults.write("GRUB_DISABLE_OS_PROBER=\"true\"\n")
  
          if self.use_bls and os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):


### PR DESCRIPTION
Qubes R4.1 use grant tables a lot for mapping GUI windows, increase
default limits to allow that. This is especially important, as in case
of grant table entries shortage, other users (PV drivers, including disk
and network) will also fail.

QubesOS/qubes-issues#5674
QubesOS/qubes-issues#5519