### PR TITLE
Remove iommu=no-igfx from grub cmdline

### DIFF
--- a/0007-Add-Qubes-grub2-default-parameters.patch
+++ b/0007-Add-Qubes-grub2-default-parameters.patch
@@ -18,18 +18,6 @@ Fixes QubesOS/qubes-issues#1313
 --
 
 --
-Many Intel processors (and BIOSes) have invalid IOMMU configuration for
-IGFX, which cause multiple problems - from screen glitches, to system
-hang.
-Since IGFX currently is still in dom0 (isn't isolated from other system
-components), disabling IOMMU for it doesn't lower overall security.
-When GUI domain will be implemented, we need to re-enable IOMMU here and
-hope hardware manufacturers will fix it in the meantime.
-
-Fixes QubesOS/qubes-issues#2836
---
-
---
 Try to update microcode as early as possible if provided.
 This option will scan all multiboot modules besides dom0 kernel. In our
 case this is perfect - there is only one other module and it is
@@ -70,7 +58,7 @@ index 1154f43d8..604ad6649 100644
          defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
          defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
          defaults.write("GRUB_THEME=\"/boot/grub2/themes/qubes/theme.txt\"\n")
-+        defaults.write("GRUB_CMDLINE_XEN_DEFAULT=\"console=none dom0_mem=min:1024M dom0_mem=max:4096M iommu=no-igfx ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096\"\n")
++        defaults.write("GRUB_CMDLINE_XEN_DEFAULT=\"console=none dom0_mem=min:1024M dom0_mem=max:4096M ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096\"\n")
 +        defaults.write("GRUB_DISABLE_OS_PROBER=\"true\"\n")
  
          if self.use_bls and os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):


### PR DESCRIPTION
We want to support passing Intel GPU to a domain.
no-igfx disables PCI passtrough for Intel GPU.

Part of: QubesOS/qubes-issues#2618