### PR TITLE
Fix "standard partitioning", set xfs as default fs there

### DIFF
--- a/0034-Fix-standard-partitioning-set-xfs-as-default-fs-ther.patch
+++ b/0034-Fix-standard-partitioning-set-xfs-as-default-fs-ther.patch
@@ -1,0 +1,76 @@
+From 496b6128d90214893c111141480cc5dac070d833 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 8 Dec 2020 17:02:04 +0100
+Subject: [PATCH] Fix "standard partitioning", set xfs as default fs there
+
+Specify separate partition layout for LVM thin and standard partitions
+(or LVM non-thin). Specifically, exclude thin pools (for VM volumes and
+dom0 root) on non-thin setup.
+
+Then, request xfs fstype for /var/lib/qubes on non-thin partitions, to
+have reflink functionality. Old 'file' storage driver is going to be
+deprecated, so don't rely on it in any of default setups.
+
+QubesOS/qubes-issues#6252
+---
+ .../automatic/automatic_partitioning.py       | 29 ++++++++++++++++++-
+ 1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+index 4ef249850..2ca735e15 100644
+--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
++++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+@@ -83,7 +83,7 @@ WORKSTATION_PARTITIONING = [
+     )
+ ]
+ 
+-QUBESOS_PARTITIONING = [
++QUBESOS_LVM_PARTITIONING = [
+     PartSpec(
+         fstype="swap",
+         grow=False,
+@@ -117,6 +117,31 @@ QUBESOS_PARTITIONING = [
+     )
+ ]
+ 
++QUBESOS_PARTITIONING = [
++    PartSpec(
++        fstype="swap",
++        grow=False,
++        lv=True,
++        encrypted=True
++    ),
++    PartSpec(
++        mountpoint="/",
++        size=Size("20GiB"),
++        required_space=Size("10GiB"),
++        grow=False,
++        lv=True,
++        encrypted=True
++    ),
++    PartSpec(
++        mountpoint="/var/lib/qubes",
++        size=Size("20GiB"),
++        fstype="xfs",
++        grow=True,
++        lv=True,
++        encrypted=True
++    )
++]
++
+ QUBESOS_BTRFS_PARTITIONING = [
+     PartSpec(
+         fstype="swap",
+@@ -155,6 +180,8 @@ def get_default_partitioning(partitioning_type=None, scheme=None):
+     if partitioning_type is PartitioningType.QUBESOS:
+         if scheme == AUTOPART_TYPE_BTRFS:
+             return platform.set_default_partitioning() + QUBESOS_BTRFS_PARTITIONING
++        elif scheme == AUTOPART_TYPE_LVM_THINP:
++            return platform.set_default_partitioning() + QUBESOS_LVM_PARTITIONING
+         else:
+             return platform.set_default_partitioning() + QUBESOS_PARTITIONING
+ 
+-- 
+2.26.2
+

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -58,6 +58,7 @@ Patch29: 0030-Add-specific-BTRFS-automatic-partitioning-scheme.patch
 Patch30: 0031-Compute-template-RPMs-needed-spaces.patch
 Patch31: 0032-dnfpayload-make-available-repos-for-post-scripts.patch
 Patch32: 0033-Set-human-names-for-Qubes-thin-pools.patch
+Patch33: 0034-Fix-standard-partitioning-set-xfs-as-default-fs-ther.patch
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).


### PR DESCRIPTION
Specify separate partition layout for LVM thin and standard partitions
(or LVM non-thin). Specifically, exclude thin pools (for VM volumes and
dom0 root) on non-thin setup.

Then, request xfs fstype for /var/lib/qubes on non-thin partitions, to
have reflink functionality. Old 'file' storage driver is going to be
deprecated, so don't rely on it in any of default setups.

Fixes QubesOS/qubes-issues#6252