### PR TITLE
Fix and update setting default kernel

### DIFF
--- a/40-qubes-alt-kernels.ks
+++ b/40-qubes-alt-kernels.ks
@@ -1,20 +1,11 @@
 %post --nochroot
 
-for pkg in /run/install/repo/extrakernels/*.rpm; do
-  name=`basename $pkg .rpm`
-  rpm --root=$ANA_INSTALL_PATH -q $name > /dev/null || rpm --root=$ANA_INSTALL_PATH -i --oldpackage $pkg
-done
-
-# Set grub default to the current kernel if running not the latest one
-latest=`basename /run/install/repo/Packages/k/kernel-[0-9]*.rpm .rpm|cut -d- -f2-`
-if [ "$latest" != "`uname -r`" ]; then
-    rootdev=`grep " $ANA_INSTALL_PATH " /proc/mounts | cut -f 1 -d ' '`
-    sysid=`blkid -o value -s UUID $rootdev`
-    xenver=`dmesg | grep 'Xen version:' | sed -e 's/.*version: \([0-9.]\+\).*/\1/'`
-    grubid="gnulinux-advanced-$sysid"
-    grubid="$grubid>xen-hypervisor-$xenver-$sysid"
-    grubid="$grubid>xen-gnulinux-`uname -r`-advanced-$sysid"
-    grub2-set-default --boot-directory=$ANA_INSTALL_PATH/boot "$grubid"
+# Install kernel-latest if running not the one that is installed already
+latest=$(rpm --root=$ANA_INSTALL_PATH --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n' -q kernel | sort -V | tail -1)
+running=$(uname -r)
+if [ "$latest" != "$running" ]; then
+    dnf --installroot=$ANA_INSTALL_PATH --setopt=reposdir=/etc/yum.repos.d -y install kernel-latest
+    dnf --installroot=$ANA_INSTALL_PATH --setopt=reposdir=/etc/yum.repos.d -y install kernel-latest-qubes-vm
 fi
 
 %end


### PR DESCRIPTION
Adjust setting default kernel to the one used during installation.
Install extra kernels (kernel-latest) only when the currently running
one isn't installed already - this avoids the need to manually force
specific kernel - grub scripts will choose the newest one.

QubesOS/qubes-issues#5900