### PR TITLE
Backport post-scripts ordering fix

### DIFF
--- a/0037-post-scripts-need-to-be-sorted.patch
+++ b/0037-post-scripts-need-to-be-sorted.patch
@@ -1,0 +1,29 @@
+From 1a2c17528cf880b1b76d3c94cbd85e781145c76c Mon Sep 17 00:00:00 2001
+From: Jan Stodola <honza.stodola@gmail.com>
+Date: Wed, 7 Oct 2020 00:39:21 +0200
+Subject: [PATCH] post-scripts need to be sorted
+
+Because glob.glob() doesn't return a sorted list.
+
+Related: rhbz#1870493
+(cherry picked from commit 0eafa6399ca4ab093d0b7dc6ca442294cc14d842)
+---
+ pyanaconda/kickstart.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyanaconda/kickstart.py b/pyanaconda/kickstart.py
+index 7dbf83971a..d26ff7e0a1 100644
+--- a/pyanaconda/kickstart.py
++++ b/pyanaconda/kickstart.py
+@@ -565,7 +565,7 @@ def appendPostScripts(ksdata):
+     scripts = ""
+ 
+     # Read in all the post script snippets to a single big string.
+-    for fn in glob.glob("/usr/share/anaconda/post-scripts/*ks"):
++    for fn in sorted(glob.glob("/usr/share/anaconda/post-scripts/*ks")):
+         f = open(fn, "r")
+         scripts += f.read()
+         f.close()
+-- 
+2.37.3
+

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -61,6 +61,7 @@ Patch32: 0033-Set-human-names-for-Qubes-thin-pools.patch
 Patch33: 0034-Fix-standard-partitioning-set-xfs-as-default-fs-ther.patch
 Patch34: 0035-Resolve-filename-into-associated-loop-device.patch
 Patch35: 0036-Set-GRUB_DISABLE_SUBMENU-false.patch
+Patch36: 0037-post-scripts-need-to-be-sorted.patch
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).


### PR DESCRIPTION
This is necessary for example for 40-qubes-alt-kernels.ks be called
after 30-qubes-templates.ks (the former depends on the latter setting up
installer.repo), or for 99-copy-logs.ks to be called last.

Related to including kernel-latest, as installing it was broken due to
this issue.

QubesOS/qubes-issues#5900