### PR TITLE
Do not force GPT on legacy BIOS install

### DIFF
--- a/qubesos.conf
+++ b/qubesos.conf
@@ -57,6 +57,8 @@ additional_default_grub_options =
     GRUB_DISABLE_OS_PROBER="true"
 
 [Storage]
+# use blivet's default: MBR on legacy, GPT on EFI
+disk_label_type =
 encrypted = True
 default_scheme = LVM_THINP
 thin_pool_size = 20GiB


### PR DESCRIPTION
This confuses some firmware that refuse to boot in legacy mode from such
disk. See referenced issue for details.

This effectively reverts
https://www.fedoraproject.org/wiki/Changes/GPTforBIOSbyDefault

QubesOS/qubes-issues#8058