### PR TITLE
Switch grub terminal to 'console'

### DIFF
--- a/qubesos.conf
+++ b/qubesos.conf
@@ -50,7 +50,7 @@ selinux = -1
 [Bootloader]
 efi_dir = qubes
 disable_grub_submenu = False
-grub_terminal_type = gfxterm
+grub_terminal_type = console
 additional_default_grub_options =
     GRUB_THEME="/boot/grub2/themes/qubes/theme.txt"
     GRUB_CMDLINE_XEN_DEFAULT="console=none dom0_mem=min:1024M dom0_mem=max:4096M ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096"


### PR DESCRIPTION
gfxterm reportedly cause issues, including complete boot failure.
Console menu is less pretty, but booting system is more important

Fixes QubesOS/qubes-issues#8464