### PR TITLE
Fix initializing clock check

### DIFF
--- a/0040-Verify-clock-against-ISO-creation.patch
+++ b/0040-Verify-clock-against-ISO-creation.patch
@@ -65,7 +65,7 @@ index f1ad774006..4d1ec92202 100644
 +            now_utc = intended_local.astimezone(datetime.timezone.utc)
 +        else:
 +            log.debug("Time set pending but widgets incomplete.")
-+            return False
++            now_utc = datetime.datetime.now(tz=datetime.timezone.utc)
 +
 +        if now_utc < iso_dt:
 +            log.error("Current clock (%s) is earlier than ISO creation (%s).",


### PR DESCRIPTION
When widget is not initialized yet, simply take system time - surely
user didn't had a chance to set something different in the widget yet.
This fixes initial state to not block installation just because UI for
changing date is not initialized.

QubesOS/qubes-issues#9686